### PR TITLE
Fix: Adapt `wait_for_pixel_color_area` to use display scaling

### DIFF
--- a/wait_for_pixel_color_area.py
+++ b/wait_for_pixel_color_area.py
@@ -1,11 +1,17 @@
 def wait_for_pixel_color_area(script_area, x1, y1, x2, y2, color, scaling=100):
-    # Преобразуем координаты в целые числа
-    x1, y1, x2, y2 = int(x1), int(y1), int(x2), int(y2)
+    # Преобразуем логические координаты в физические (экранные) координаты
+    # x1, y1, x2, y2 приходят уже как int из event_handler
+
+    screen_x1 = int(x1 * (scaling / 100))
+    screen_y1 = int(y1 * (scaling / 100))
+    screen_x2 = int(x2 * (scaling / 100))
+    screen_y2 = int(y2 * (scaling / 100))
     
     # Генерируем код для ожидания появления цвета в области
+    # PixelSearch в AutoIt ожидает экранные координаты
     code = (
         'While 1\n'
-        f'    Local $aCoord = PixelSearch({x1}, {y1}, {x2}, {y2}, {color}, 1)\n'
+        f'    Local $aCoord = PixelSearch({screen_x1}, {screen_y1}, {screen_x2}, {screen_y2}, {color}, 1)\n'
         '    If IsArray($aCoord) Then\n'
         '        ExitLoop\n'
         '    Else\n'


### PR DESCRIPTION
The function `wait_for_pixel_color_area` now correctly uses the `scaling` parameter to convert logical coordinates (scaled by the application) back to physical screen coordinates before generating the AutoIt `PixelSearch` command.

This ensures that the area you selected on screen, regardless of the application's display scaling setting, is accurately reflected in the AutoIt script.